### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://andrewdvizhok.visualstudio.com/d26298e0-1525-4ede-afc5-67d26f61ef43/3f2b2319-c0b7-41c2-ad40-8625cb3a01bd/_apis/work/boardbadge/ecfb26f3-7c9d-477d-bf96-6b9756e18ee7)](https://andrewdvizhok.visualstudio.com/d26298e0-1525-4ede-afc5-67d26f61ef43/_boards/board/t/3f2b2319-c0b7-41c2-ad40-8625cb3a01bd/Microsoft.RequirementCategory)
 # genteic


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://andrewdvizhok.visualstudio.com/d26298e0-1525-4ede-afc5-67d26f61ef43/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.